### PR TITLE
Adding a '\r' in the assertion, 

### DIFF
--- a/src/test/java/com/springsource/greenhouse/account/WelcomeMailTransformerTest.java
+++ b/src/test/java/com/springsource/greenhouse/account/WelcomeMailTransformerTest.java
@@ -21,6 +21,6 @@ public class WelcomeMailTransformerTest {
 		assertEquals("Greenhouse <noreply@springsource.com>", welcomeMail.getFrom());
 		assertEquals("Welcome to the Greenhouse!", welcomeMail.getSubject());
 		String mailText = welcomeMail.getText();
-		assertTrue(mailText.contains("View your member profile at:\nhttp://greenhouse.springsource.org/members/rclarkson"));
+		assertTrue(mailText.contains("View your member profile at:\r\nhttp://greenhouse.springsource.org/members/rclarkson"));
 	}
 }


### PR DESCRIPTION
In WIN7, this is causing the test to fail, due to missing '\r' character.
