### PR TITLE
SAXParseException due to authentication-failed-url in oauth:provider

### DIFF
--- a/src/main/java/com/springsource/greenhouse/config/security-oauth-provider.xml
+++ b/src/main/java/com/springsource/greenhouse/config/security-oauth-provider.xml
@@ -15,7 +15,7 @@
 	<!-- Spring Security OAuth 1.0 Provider Configuration -->	
 	<oauth:provider consumer-details-service-ref="appConsumerDetailsService" token-services-ref="oauthProviderTokenServices"
 		request-token-url="/oauth/request_token" authenticate-token-url="/oauth/authorize"
-		authentication-failed-url="/oauth/confirm_access" access-token-url="/oauth/access_token" require10a="false" />
+		user-approval-url="/oauth/confirm_access" access-token-url="/oauth/access_token" require10a="false" />
 
 	<!-- Sends a UNAUTHORIZED response back to clients attempting to access protected resources but who have not yet authenticated via OAuth -->
 	<bean id="oauthAuthenticationEntryPoint" class="org.springframework.security.oauth.provider.OAuthProcessingFilterEntryPoint">


### PR DESCRIPTION
I'm getting a SAXParseException cause of the authentication-failed-url attribute of oauth:provider, seems like this was changed to user-approval-url?

Caused by: org.xml.sax.SAXParseException: cvc-complex-type.3.2.2: Attribute 'authentication-failed-url' is not allowed to appear in element 'oauth:provider'.

Please refer to this post: http://forum.springsource.org/showthread.php?125050-Oauth1-User-authentication-is-skipped-for-Token-Authorization

PS: However now I'm getting a error in STS 3M1 XML Editor.
